### PR TITLE
Update jax.partial to functools.partial 

### DIFF
--- a/jaxfg/core/_stacked_factor_graph.py
+++ b/jaxfg/core/_stacked_factor_graph.py
@@ -260,7 +260,7 @@ class StackedFactorGraph:
         )
         return A
 
-    # @jax.partial(jax.jit, static_argnums=2)
+    # @functools.partial(jax.jit, static_argnums=2)
     # def _compute_variable_hessian_block(
     #     self, assignments: VariableAssignments, variable: VariableBase
     # ) -> hints.Array:

--- a/jaxfg/solvers/_fixed_iteration_gauss_newton_solver.py
+++ b/jaxfg/solvers/_fixed_iteration_gauss_newton_solver.py
@@ -1,3 +1,4 @@
+import functools
 from typing import TYPE_CHECKING
 
 import jax
@@ -108,7 +109,7 @@ class FixedIterationGaussNewtonSolver(NonlinearSolverBase[NonlinearSolverState])
         else:
             state = jax.lax.while_loop(
                 cond_fun=lambda state: jnp.logical_not(state.done),
-                body_fun=jax.partial(self._step, graph),
+                body_fun=functools.partial(self._step, graph),
                 init_val=state,
             )
 

--- a/jaxfg/solvers/_nonlinear_solver_base.py
+++ b/jaxfg/solvers/_nonlinear_solver_base.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 from typing import TYPE_CHECKING, Callable, Generic, TypeVar, Union
 
 import jax
@@ -88,7 +89,7 @@ class NonlinearSolverBase(
         # Optimization
         state = jax.lax.while_loop(
             cond_fun=lambda state: jnp.logical_not(state.done),
-            body_fun=jax.partial(self._step, graph),
+            body_fun=functools.partial(self._step, graph),
             init_val=state,
         )
 


### PR DESCRIPTION
Hey @brentyi 
In the latest jax-version `jax.partial` was replaced in favor of `functools.partial`. Should be fixed by this PR
https://github.com/google/jax/releases/tag/jax-v0.2.21